### PR TITLE
Ability to set BUY and SELL Offset in PERCENT + various improvements

### DIFF
--- a/bot/commands/check/_utils.ts
+++ b/bot/commands/check/_utils.ts
@@ -99,7 +99,7 @@ export async function checkUpdateAvailable() {
 
     if (onlineVersion > localVersion) {
         console.log(styleText('cyan', '\nUpdate available'));
-        console.log('git pull');
+        console.log('git pull --rebase');
         console.log('bun update')
     } else {
         console.log(styleText('green', '✅  Project updated'));

--- a/bot/commands/new/index.ts
+++ b/bot/commands/new/index.ts
@@ -2,57 +2,64 @@ import * as Exchange from '../../services/exchange';
 import {getAmountPlayable} from './_utils.ts';
 import * as Cycle from '../../database/cycle'
 
-
-export default async function () {
+export default async function (dryRun: boolean) {
+    // Get last BTC price in USDT
     const lastPrice = (await Exchange.getLastPrice()).lastPriceNumber;
     console.log(`ℹ️ Last price = ${lastPrice}`);
 
+    // Read BUY_OFFSET from .env and computes a lower buy price (in percent if BUY_OFFSET ends with a % sign)
     let buyOffset: string | number = String(process.env.BUY_OFFSET);
-    buyOffset = parseInt(buyOffset);
+    const buyOffsetPercent = buyOffset.endsWith('%');
+    buyOffset = parseFloat(buyOffset);
     buyOffset = Math.abs(buyOffset);
-
+    
+    const priceInput = (buyOffsetPercent) ? lastPrice / (1 + (buyOffset / 100.0)) : lastPrice - buyOffset;
+    console.log(`ℹ️ Price input = ${priceInput}`);
+ 
+    // Read SELL_OFFSET from .env and computes a higher buy price (in percent if SELL_OFFSET ends with a % sign)
     let sellOffset: string | number = String(process.env.SELL_OFFSET);
-    sellOffset = parseInt(sellOffset);
+    const sellOffsetPercent = sellOffset.endsWith('%');
+    sellOffset = parseFloat(sellOffset);
     sellOffset = Math.abs(sellOffset);
 
-    const priceInput = lastPrice - buyOffset;
-    const priceOutput = lastPrice + sellOffset;
-
-    console.log(`ℹ️ Price input = ${priceInput}`);
+    const priceOutput = (sellOffsetPercent) ? lastPrice * (1 + (sellOffset / 100.0)) : lastPrice + sellOffset;
     console.log(`ℹ️ Price output = ${priceOutput}`);
 
+    // Get available USDT amount from Exchange and compute a bag for this trade
     const amountPlayableUSDT = await getAmountPlayable();
     console.log(`ℹ️ Amount playable in USD = ${amountPlayableUSDT}`);
 
+    // Convert playable amount into BTC (at computed buy price)
     let amountPlayableBTC: Number | String = (parseFloat(amountPlayableUSDT) / priceInput).toFixed(6);
     amountPlayableBTC = String(amountPlayableBTC);
     console.log(`ℹ️ Amount playable in BTC = ${amountPlayableBTC}`);
 
-    // create order in exchange
-    const order = await Exchange.createOrder({
-        symbol: 'BTC_USDT',
-        side: 'buy',
-        price: String(priceInput),
-        quantity: String(amountPlayableBTC),
-    });
+    if (!dryRun) {
+        // create order in exchange
+        const order = await Exchange.createOrder({
+            symbol: 'BTC_USDT',
+            side: 'buy',
+            price: String(priceInput),
+            quantity: String(amountPlayableBTC),
+        });
 
-    if (order.hasOwnProperty('error')) {
-        console.log('error !');
-        console.log(order);
-        process.exit();
+        if (order.hasOwnProperty('error')) {
+            console.log('error !');
+            console.log(order);
+            process.exit();
+        }
+
+        console.log(order)
+        console.log(`ℹ️ Order successfully placed`);
+
+        // Store order in db
+        const cycleID = Cycle.insert({
+            quantity: parseFloat(amountPlayableBTC.toString()),
+            order_buy_price: priceInput,
+            order_buy_id: order.id,
+            order_sell_price: priceOutput
+        });
+        console.log(`ℹ️ Cycle successfully inserted in database`);
     }
-
-    console.log(order)
-    console.log(`ℹ️ Order successfully placed`);
-
-    // insert in db
-    const cycleID = Cycle.insert({
-        quantity: parseFloat(amountPlayableBTC.toString()),
-        order_buy_price: priceInput,
-        order_buy_id: order.id,
-        order_sell_price: priceOutput
-    });
-    console.log(`ℹ️ Cycle successfully inserted in database`);
-
     process.exit();
 }

--- a/bot/commands/update/index.ts
+++ b/bot/commands/update/index.ts
@@ -2,66 +2,80 @@ import * as Exchange from '../../services/exchange';
 import * as Cycle from '../../database/cycle';
 import {type CycleType, type OrderType, Status} from '../../types';
 
-export default async function () {
+export default async function (dryRun: boolean) {
+    // Get last BTC price in USDT
     const lastPrice = (await Exchange.getLastPrice()).lastPriceNumber as number;
 
+    // Read running cycles from database
     const uncompletedCycles = Cycle.listUncompleted() as Array<CycleType>
     for (const cycle of uncompletedCycles) {
 
         const {id: cycleId, status, order_buy_id, order_sell_price, quantity, order_sell_id}: CycleType = cycle;
 
-        if (status === Status.ORDER_BUY_PLACED) {
-            const order = await Exchange.getOrder(order_buy_id as string)
+        switch(status) {
+            case Status.ORDER_BUY_PLACED:
+                const buy_order = await Exchange.getOrder(order_buy_id as string)
 
-            if (order.isActive) {
-                console.log(`Buy order ${order_buy_id} still active`);
-
-            } else {
-                console.log(`Buy order ${order_buy_id} filled`);
-
-                console.log(`Start updating cycle ${cycle.id}`);
-
-                Cycle.updateStatus(cycleId as number, Status.ORDER_BUY_FILLED);
-
-                if ( lastPrice > Number(order_sell_price) ) {
-                    const newSellPrice = Number(cycle.order_sell_price) + 100
-                    Cycle.updateOrderSellPrice(Number(cycle.id), newSellPrice)
+                if (buy_order.isActive) {
+                    console.log(`Buy order ${order_buy_id} still active`);
+                    continue;
                 }
 
-                let price = Cycle.getById(
-                    Number(cycleId)
-                ) as string;
-                price = String(order_sell_price);
+                console.log(`Buy order ${order_buy_id} filled`);
+                console.log(`Start updating cycle ${cycle.id}`);
 
-                const orderSell: OrderType = await Exchange.createOrder({
-                    symbol: 'BTC_USDT',
-                    side: 'sell',
-                    price,
-                    quantity: String(quantity)
-                });
+                if (!dryRun) {
+                    Cycle.updateStatus(cycleId as number, Status.ORDER_BUY_FILLED);
+                }
 
-                Cycle.updateOrderSellId(
-                    Number(cycleId),
-                    String(orderSell.id)
-                );
+                if (lastPrice > Number(order_sell_price)) {
+                    // TODO: this should be a configurable constant ------v 
+                    const newSellPrice = Number(cycle.order_sell_price) + 100
+                    if (!dryRun) {
+                        Cycle.updateOrderSellPrice(Number(cycle.id), newSellPrice)
+                    }
+                }
 
-                Cycle.updateStatus(
-                    Number(cycleId),
-                    Status.ORDER_SELL_PLACED
-                );
-            }
-        } else if (status === Status.ORDER_SELL_PLACED) {
-            const order = await Exchange.getOrder(order_sell_id as string)
-            if (order.isActive) {
-                console.log(`Sell order ${order_sell_id} still active`);
-            } else {
+                if (!dryRun) {
+                    let price = Cycle.getById(
+                        Number(cycleId)
+                    ) as string;
+                    price = String(order_sell_price);
+
+                    const orderSell: OrderType = await Exchange.createOrder({
+                        symbol: 'BTC_USDT',
+                        side: 'sell',
+                        price,
+                        quantity: String(quantity)
+                    });
+
+                    Cycle.updateOrderSellId(
+                        Number(cycleId),
+                        String(orderSell.id)
+                    );
+
+                    Cycle.updateStatus(
+                        Number(cycleId),
+                        Status.ORDER_SELL_PLACED
+                    );
+                }
+                break;
+
+            case Status.ORDER_SELL_PLACED:
+                const sell_order = await Exchange.getOrder(order_sell_id as string)
+                if (sell_order.isActive) {
+                    console.log(`Sell order ${order_sell_id} still active`);
+                    continue;
+                }
+            
+                // Even in --dry-run mode, this should be updated in database
                 Cycle.updateStatus(
                     Number(cycleId),
                     Status.COMPLETED
                 );
 
                 console.log(`Cycle ${cycleId} successfully completed`);
-            }
+                break;
         }
     }
 

--- a/main.ts
+++ b/main.ts
@@ -1,36 +1,58 @@
+import { parseArgs } from "util";
+
 import check from './bot/commands/check';
 import server from './bot/commands/server'
 import startNewCycle from './bot/commands/new';
-import update from './bot/commands/update';
+import updateCycles from './bot/commands/update';
 
 function menu() {
-    console.log('\nSimple Trading Bot v2 \n');
-    console.log('--check      -c    Check config \n');
-    console.log('--new        -n    Start new cycle \n');
-    console.log('--update     -u    Update running cycles \n');
-    console.log('--server     -s    Run server \n');
+    console.log('\nSimple Trading Bot v2.1');
+    console.log('\nCommands: (c)heck, (n)ew, (u)pdate, (s)erve\n')
+    console.log('   check                      Check config');
+    console.log('   new        [--dry-run]     Start new cycle');
+    console.log('   update     [--dry-run]     Update running cycles');
+    console.log('   serve                      Run server');
+    console.log('\nParameters:')
+    console.log('   --dry-run                  Do not place order in Exchange (and do not change the database)')
     process.exit();
 }
 
-const lastArg = Bun.argv.at(-1);
+const { values, positionals } = parseArgs({
+    args: Bun.argv,
+    options: {
+        "dry-run": {
+            type: 'boolean',
+            default: false
+        }
+    },
+    strict: true,
+    allowPositionals: true,
+});
 
-switch (lastArg) {
-    case '-c':
-    case '--check':
+const command = positionals.at(-1)
+const dryRun = values["dry-run"] || false
+
+switch (command) {
+    case 'c':
+    case 'check':
         await check();
         break;
-    case '-n':
-    case '--new':
-        await startNewCycle();
+    
+    case 'n':
+    case 'new':
+        await startNewCycle(dryRun);
         break;
-    case '-u':
-    case '--update':
-        await update();
+    
+    case 'u':
+    case 'update':
+        await updateCycles(dryRun);
         break;
-    case '-s':
-    case '--server':
+        
+    case 's':
+    case 'serve':
         server();
         break;
+
     default:
         menu();
 }


### PR DESCRIPTION
I changed command line args parsing to use node `utils.parseArgs()` and so I changed the syntax to use a "command" oriented CLI.

Instead of `bun run ./main.ts -n[ew]` you should use `bun run ./main.ts n[ew]` (same for c[heck], u[pdate] and s[erve])

I also added a `--dry-run` parameter that applies to `n[ew]` and `u[pdate]` commands : if specified, orders are not placed in the exchange and the database is not updated.